### PR TITLE
master chain min probability should be max not min

### DIFF
--- a/reporter.py
+++ b/reporter.py
@@ -485,7 +485,7 @@ class Reporter(MTC):
         if not active_validator:
             return self.MIN_PROB_NULL
 
-        return min(validator_load['mc_prob'], validator_load['wc_prob'])
+        return max(validator_load['mc_prob'], validator_load['wc_prob'])
 
     def check_fine_changes(self, mytoncore_db):
 


### PR DESCRIPTION
In case validator is closing blocks on master chain 

so we should not trigger an exit flag if we close blocks on either chains , 
thats why it needs to be the optimistic case and the worst case 

Correct ? 